### PR TITLE
Delete unnecessary controller code

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,10 +7,6 @@ class EventsController < ApplicationController
     @previous = Event.previous.includes(:location)
   end
 
-  def show
-    @event = Event.find_by!(slug: params[:id])
-  end
-
   def new
     @event = Event.new_with_defaults
   end


### PR DESCRIPTION
Just a minor thing I spotted that could be tidied up.

---

The code in EventsController#show just repeats the code in the
find_event filter, and so the entire method can be removed.