### PR TITLE
Display "Talks start:" time for future events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,6 +20,10 @@ class Event < ActiveRecord::Base
     end
   end
 
+  def talk_start_time
+    (date + 30.minutes).strftime('%l:%M%P').strip
+  end
+
   def time
     date.strftime('%l:%M%P').strip
   end

--- a/app/views/events/_aside.html.erb
+++ b/app/views/events/_aside.html.erb
@@ -3,6 +3,9 @@
     <h2>Next Event: <%= next_event.date.to_s(:short_date) %></h2>
     <h3><%= link_to next_event.title, event_path(next_event) %></h3>
     <h4><%= next_event.time %> at <%= next_event.location.name %></h4>
+    <% if next_event.location.name && next_event.date > (Time.now - 1.hour) %>
+      <small>Talks start: <%= next_event.talk_start_time %></small>
+    <% end %>
   <% else %>
     <h2>Next Event: <%= Event.next_date.to_s(:short_date) %></h2>
     <p>Details to follow&hellip;</p>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,4 +1,7 @@
 <li>
   <h3><%= link_to event.title, event %></h3>
   <p><%= event.date.to_s(:short_date) %> <%= event.time %> at <%= event.location.name %></p>
+  <% if event.location.name && event.date > (Time.now - 1.hour) %>
+    <small>Talks start: <%= event.talk_start_time %></small>
+  <% end %>
 </li>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,6 +10,9 @@
 
   <h1 class="large-heading"><%= @event.title %></h1>
   <h2 class="secondary-colour"><%= @event.date.to_s(:short_date) %> <%= @event.time %> at <%= @event.location.name %></h2>
+  <% if @event.location && @event.date > (Time.now - 1.hour) %>
+    <small>Doors: <%= @event.time %> - Talks Starts: <%= @event.talk_start_time %></small>
+  <% end %>
 
   <%= render_markdown @event.description %>
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -33,6 +33,11 @@ class EventTest < ActiveSupport::TestCase
     assert_equal "7:00pm", event.time
   end
 
+  test "#talk_start_time returns the time when we usually start talks" do
+    event = create_event!(date: DateTime.new(2015, 8, 1, 19, 0))
+    assert_equal "7:30pm", event.talk_start_time
+  end
+
   test "Event.new_with_defaults sets the date to the next probable date (third Thursday, 6:30pm)" do
     travel_to Date.new(2015, 8, 21) do
       event = Event.new_with_defaults


### PR DESCRIPTION
Dynamically generated from the event timestamp. It will continue to display until 1 hour after the scheduled event.

![screenshot 2017-02-17 14 47 13](https://cloud.githubusercontent.com/assets/110469/23069703/63147312-f520-11e6-8cd1-f83237a8c306.jpg)
![screenshot 2017-02-17 14 46 25](https://cloud.githubusercontent.com/assets/110469/23069705/63264560-f520-11e6-99f1-edde6de97aa8.jpg)
![screenshot 2017-02-17 14 46 15](https://cloud.githubusercontent.com/assets/110469/23069704/6318298a-f520-11e6-98cb-f7ad99aad0c9.jpg)
