### PR TITLE
Improve font performance with dns-prefetch

### DIFF
--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -1,2 +1,1 @@
-@import url(//fonts.googleapis.com/css?family=Lato);
-@import url(//fonts.googleapis.com/css?family=Ubuntu:300,400,700,400italic);
+@import url(//fonts.googleapis.com/css?family=Lato|Ubuntu:300,400,400i,700);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html class="no-js" lang="">
 <head>
   <meta charset="utf-8">
+  <link rel="dns-prefetch" href="https://fonts.googleapis.com">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title><%= yield :meta_title %></title>
   <meta name="description" content="<%= yield :meta_description %>">


### PR DESCRIPTION
I was doing some request checks, and we happen to use Lato and Ubuntu fonts from Google API.
So this PR moves the two requests into a single request and adds a DNS-Prefetch to ensure the font's are loaded as quick as possible.


---

Personally we could get away with not using a custom font if needed and simply use the [Native font stack](https://getbootstrap.com/docs/4.0/content/reboot/#native-font-stack)

```css
# from https://github.com/twbs/bootstrap/blob/v4-dev/dist/css/bootstrap-reboot.css#L33

font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
```
