### PR TITLE
Move IntelliCentrics to end of list in seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,13 +9,6 @@ require 'csv'
 
 LOCATIONS = [
   {
-    name: 'IntelliCentrics UK',
-    website: 'https://intellicentrics.co.uk/',
-    street_address: '55 Spring Gardens',
-    city: 'Manchester',
-    postal_code: 'M2 2BY',
-  },
-  {
     name: 'The Manchester Digital Laboratory (MadLab)',
     website: 'http://madlab.org.uk',
     street_address: '36-40 Edge Street',
@@ -83,6 +76,13 @@ LOCATIONS = [
     street_address: 'New Broadcasting House, Oxford Rd',
     city: 'Manchester',
     postal_code: 'M1 5QA',
+  },
+  {
+    name: 'IntelliCentrics UK',
+    website: 'https://intellicentrics.co.uk/',
+    street_address: '55 Spring Gardens',
+    city: 'Manchester',
+    postal_code: 'M2 2BY',
   },
 ]
 


### PR DESCRIPTION
Adding new location to start of list messes up in foreign keys of existing events, so I’ve moved it to the end.

This is perhaps only a minor issue, but having the locations of events match where they actually took place gives better confidence that you’ve set everything up correctly.


